### PR TITLE
Redesign player page with modern two-panel streaming UI (#74)

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,8 +95,13 @@
         }
     }
 
+    .lyric-button {
+        font-size: var(--lyric-font-size);
+    }
+
     .lyric-button.active {
-        @apply max-w-60 md:max-w-[50%] text-3xl p-2 font-bold text-pretty;
+        @apply max-w-60 md:max-w-[50%] p-2 font-bold text-pretty;
+        font-size: calc(var(--lyric-font-size) * 1.1);
     }
 
     .lyric-button.active {

--- a/web/components/player/LyricLine.vue
+++ b/web/components/player/LyricLine.vue
@@ -29,7 +29,7 @@ defineEmits<{ (e: "jump", index: number): void }>();
 <template>
     <div
         :id="`lyric-line-${index}`"
-        class="lyric-line mx-6 my-7 md:my-9"
+        class="lyric-line mx-6 my-8 md:my-12"
         :class="{
             'is-duet': isDuet,
             'is-secondary-vocalist': line.is_secondary,

--- a/web/components/player/LyricLine.vue
+++ b/web/components/player/LyricLine.vue
@@ -29,7 +29,7 @@ defineEmits<{ (e: "jump", index: number): void }>();
 <template>
     <div
         :id="`lyric-line-${index}`"
-        class="lyric-line mx-6 my-10"
+        class="lyric-line mx-6 my-7 md:my-9"
         :class="{
             'is-duet': isDuet,
             'is-secondary-vocalist': line.is_secondary,
@@ -39,7 +39,7 @@ defineEmits<{ (e: "jump", index: number): void }>();
         <button
             :id="`line-button-${index}`"
             type="button"
-            class="z-1 lyric-button text-2xl bg-transparent p-0 cursor-pointer max-w-[50%] relative"
+            class="z-1 lyric-button bg-transparent p-0 cursor-pointer max-w-[50%] relative"
             :class="{ active: isCurrent }"
             @click="$emit('jump', index)"
         >

--- a/web/components/player/LyricPhrase.vue
+++ b/web/components/player/LyricPhrase.vue
@@ -19,7 +19,7 @@ defineProps<{
         :class="{
             active: isActive,
             kiai: phrase.kiai,
-            'text-lg': isBackground,
+            'text-base': isBackground,
         }"
         :duration="duration * 100"
         :delay="delay * 100"

--- a/web/components/player/LyricsContainer.vue
+++ b/web/components/player/LyricsContainer.vue
@@ -38,60 +38,64 @@ const { translationText, backgroundTranslationText, translationAuthor } =
 </script>
 
 <template>
-    <div
-        id="lyrics-container"
-        class="scroll-smooth snap-y snap-proximity p-4 w-full h-full relative"
-        :class="{ 'bg-[#3b3a3a]': !enableLyricBackground }"
-        :style="{ '--lyric-font-size': lyricFontSize + 'px' }"
-    >
+    <div class="lyrics-wrapper relative w-full h-full">
         <div
-            class="h-full md:overflow-y-auto md:overflow-x-hidden rounded-2xl relative pb-[15vh]"
-            style="scrollbar-width: none"
+            id="lyrics-container"
+            class="scroll-smooth snap-y snap-proximity p-4 w-full h-full relative"
+            :class="{ 'bg-[#3b3a3a]': !enableLyricBackground }"
+            :style="{ '--lyric-font-size': lyricFontSize + 'px' }"
         >
-            <LyricLine
-                v-for="(line, index) in lines"
-                :key="index"
-                :line="line"
-                :bg-line="line.background_voice"
-                :index="index"
-                :total-lines="lines.length"
-                :is-current="isCurrentLine(index)"
-                :is-duet="isDuet"
-                :current-time="currentTime"
-                :enable-pronounciation="enablePronounciation"
-                :get-phrase-style="getPhraseStyle"
-                :get-background-phrase-style="getBackgroundPhraseStyle"
-                :is-active-phrase="isActivePhrase"
-                @jump="
-                    try {
-                        $emit('jump', $event);
-                    } catch (e) {
-                        console.error('Failed to emit jump event:', e);
-                    }
-                "
-            />
+            <div
+                class="h-full overflow-y-auto overflow-x-hidden rounded-2xl relative pr-4 md:pr-8 pb-[15vh]"
+                style="scrollbar-width: none"
+            >
+                <LyricLine
+                    v-for="(line, index) in lines"
+                    :key="index"
+                    :line="line"
+                    :bg-line="line.background_voice"
+                    :index="index"
+                    :total-lines="lines.length"
+                    :is-current="isCurrentLine(index)"
+                    :is-duet="isDuet"
+                    :current-time="currentTime"
+                    :enable-pronounciation="enablePronounciation"
+                    :get-phrase-style="getPhraseStyle"
+                    :get-background-phrase-style="getBackgroundPhraseStyle"
+                    :is-active-phrase="isActivePhrase"
+                    @jump="
+                        try {
+                            $emit('jump', $event);
+                        } catch (e) {
+                            console.error('Failed to emit jump event:', e);
+                        }
+                    "
+                />
+            </div>
+
+            <!-- 背景圖 -->
+            <div
+                v-if="enableLyricBackground"
+                class="absolute inset-0 pointer-events-none overflow-hidden rounded-2xl select-none"
+            >
+                <img
+                    :src="song.art"
+                    :alt="song.folder"
+                    class="animate-background w-full h-full object-cover opacity-50 brightness-50 blur-xl relative overflow-hidden translate-z-0 backface-hidden"
+                />
+            </div>
         </div>
 
-        <!-- 背景圖 -->
-        <div
-            v-if="enableLyricBackground"
-            class="absolute inset-0 pointer-events-none overflow-hidden rounded-2xl select-none"
-        >
-            <img
-                :src="song.art"
-                :alt="song.folder"
-                class="animate-background w-full h-full object-cover opacity-50 brightness-50 blur-xl relative overflow-hidden translate-z-0 backface-hidden"
-            />
-        </div>
+        <!-- 翻譯列：與歌詞容器對齊 -->
+        <TranslationBar
+            v-if="enableTranslation"
+            :song="song"
+            :translation-text="translationText"
+            :background-translation-text="backgroundTranslationText"
+            :translation-author="translationAuthor"
+            @disable-translation="enableTranslation = false"
+        />
     </div>
-    <TranslationBar
-        v-if="enableTranslation"
-        :song="song"
-        :translation-text="translationText"
-        :background-translation-text="backgroundTranslationText"
-        :translation-author="translationAuthor"
-        @disable-translation="enableTranslation = false"
-    />
 </template>
 
 <style scoped>

--- a/web/components/player/LyricsContainer.vue
+++ b/web/components/player/LyricsContainer.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
     enablePronounciation: boolean;
     enableLyricBackground: boolean;
     enableTranslation: boolean;
+    lyricFontSize: number;
     isCurrentLine: (index: number) => boolean;
     getPhraseStyle: (lineIndex: number, phraseIndex: number) => CSSProperties;
     getBackgroundPhraseStyle: (
@@ -28,7 +29,6 @@ const props = defineProps<{
 defineEmits<{ (e: "jump", index: number): void }>();
 const isDuet = computed(() => props.song.is_duet);
 
-// 在 <script setup> 中
 const { translationText, backgroundTranslationText, translationAuthor } =
     useTranslation(
         () => props.song,
@@ -40,11 +40,12 @@ const { translationText, backgroundTranslationText, translationAuthor } =
 <template>
     <div
         id="lyrics-container"
-        class="scroll-smooth snap-y snap-proximity p-4 w-full relative mb-[30vh] md:mb-10"
+        class="scroll-smooth snap-y snap-proximity p-4 w-full h-full relative"
         :class="{ 'bg-[#3b3a3a]': !enableLyricBackground }"
+        :style="{ '--lyric-font-size': lyricFontSize + 'px' }"
     >
         <div
-            class="md:h-svh md:overflow-scroll md:overflow-x-hidden rounded-2xl relative"
+            class="h-full md:overflow-y-auto md:overflow-x-hidden rounded-2xl relative pb-[15vh]"
             style="scrollbar-width: none"
         >
             <LyricLine
@@ -82,8 +83,6 @@ const { translationText, backgroundTranslationText, translationAuthor } =
                 class="animate-background w-full h-full object-cover opacity-50 brightness-50 blur-xl relative overflow-hidden translate-z-0 backface-hidden"
             />
         </div>
-
-        <div v-if="enableTranslation" class="md:h-[15vh] h-0" />
     </div>
     <TranslationBar
         v-if="enableTranslation"

--- a/web/components/player/LyricsContainer.vue
+++ b/web/components/player/LyricsContainer.vue
@@ -41,12 +41,12 @@ const { translationText, backgroundTranslationText, translationAuthor } =
     <div class="lyrics-wrapper relative w-full h-full">
         <div
             id="lyrics-container"
-            class="scroll-smooth snap-y snap-proximity p-4 w-full h-full relative"
+            class="scroll-smooth snap-y snap-proximity p-4 w-full h-full relative mr-4 md:mr-12"
             :class="{ 'bg-[#3b3a3a]': !enableLyricBackground }"
             :style="{ '--lyric-font-size': lyricFontSize + 'px' }"
         >
             <div
-                class="h-full overflow-y-auto overflow-x-hidden rounded-2xl relative pr-4 md:pr-8 pb-[15vh]"
+                class="h-full overflow-y-auto overflow-x-hidden rounded-2xl relative pb-[15vh]"
                 style="scrollbar-width: none"
             >
                 <LyricLine

--- a/web/components/player/Player.vue
+++ b/web/components/player/Player.vue
@@ -29,8 +29,12 @@ import {
     TSL_PLAYER_LINK_BASE,
     TSL_SUFFIX,
 } from "@/composables/utils/config";
-import { copyToClipboard, formatTime, scrollToLineIndex } from "@/composables/utils/global";
-import type { Color } from "@/types/song_select";
+import {
+    copyToClipboard,
+    formatTime,
+    scrollToLineIndex,
+} from "@/composables/utils/global";
+import { useAlbumColors } from "@/composables/hooks/useAlbumColors";
 import AboutModal from "@components/player/AboutModal.vue";
 import CreditModal from "@components/player/CreditModal.vue";
 import ErrorDisplay from "@components/player/ErrorDisplay.vue";
@@ -40,7 +44,6 @@ import PlayerNav from "@components/player/PlayerNav.vue";
 import SettingModal from "@components/player/SettingModal.vue";
 import ShareModal from "@components/player/ShareModal.vue";
 import YTPlayer from "@components/player/YTPlayer.vue";
-import colorOptions from "@composables/colorOptions.json";
 
 // ── URL 參數 ─────────────────────────────────────────────────────────────
 const params = new URL(document.URL).searchParams;
@@ -84,26 +87,9 @@ const creditModalOpen = ref(false);
 const shareModalOpen = ref(false);
 const aboutModalOpen = ref(false);
 
-// ── 顏色 ─────────────────────────────────────────────────────────────────
-const colorOptionsList = ref<Color[]>(
-    colorOptions || [{ color: "#365456", name: "預設 II：礦石靛" }],
-);
-
-const bodyBackgroundColor = ref(
-    localStorage.getItem("bodyBackgroundColor") ?? "#365456",
-);
-
-watch(bodyBackgroundColor, (newColor) => {
-    document.body.style.backgroundColor = newColor;
-    localStorage.setItem("bodyBackgroundColor", newColor);
-});
-
-const bgColor = computed(
-    () =>
-        colorOptionsList.value.find(
-            (x) => x.color === bodyBackgroundColor.value,
-        ) ??
-        colorOptionsList.value[0] ?? { color: "#56773f", name: "預設顏色" },
+// ── 專輯封面漸層背景 ─────────────────────────────────────────────────
+const { colors: albumColors } = useAlbumColors(
+    () => currentSong.value?.art,
 );
 
 // ── 時間格式 ─────────────────────────────────────────────────────────────
@@ -118,7 +104,10 @@ const durationPercent = computed(() => {
 
 const progressBarSeek = (event: MouseEvent) => {
     const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
-    const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+    const ratio = Math.max(
+        0,
+        Math.min(1, (event.clientX - rect.left) / rect.width),
+    );
     window.ytPlayer?.seekTo(ratio * songDuration.value, true);
 };
 
@@ -132,9 +121,11 @@ const currentSongURI = computed(() => {
 
 // ── 當前影片 ID ──────────────────────────────────────────────────────────
 const currentVideoId = computed(() => {
-    return currentSong.value?.versions.find(
-        (v: Version) => v.version === songVersion.value,
-    )?.id ?? null;
+    return (
+        currentSong.value?.versions.find(
+            (v: Version) => v.version === songVersion.value,
+        )?.id ?? null
+    );
 });
 
 // ── processedLines：計算每行結束時間 ─────────────────────────────────────
@@ -346,8 +337,8 @@ onUnmounted(() => {
 <template>
     <div
         id="body"
-        class="h-screen m-0! flex flex-col overflow-hidden"
-        :style="{ backgroundColor: bodyBackgroundColor }"
+        class="h-screen m-0! flex flex-col overflow-hidden transition-[background] duration-1000"
+        :style="{ backgroundImage: albumColors.gradient }"
     >
         <!-- 載入中 -->
         <LoadingOverlay v-if="isLoading" />
@@ -359,21 +350,23 @@ onUnmounted(() => {
 
         <template v-if="!isLoading && !isError && currentSong">
             <!-- 頂部導覽 -->
-            <PlayerNav :body-background-color="bodyBackgroundColor" />
+            <PlayerNav :dominant-color="albumColors.dominant" />
 
             <!-- ═══════════════════════════════════════════════════════════ -->
             <!-- 桌面版：兩欄式佈局                                        -->
             <!-- ═══════════════════════════════════════════════════════════ -->
-            <div
-                class="hidden md:flex flex-1 overflow-hidden pt-20"
-            >
+            <div class="hidden md:flex flex-1 overflow-hidden pt-20">
                 <!-- ── 左側面板：影片 + 歌曲資訊 + 控制 ── -->
                 <div
-                    class="left-panel flex flex-col items-center w-[40%] lg:w-[35%] overflow-y-auto px-6 py-6"
+                    class="left-panel flex flex-col items-center w-[40%] lg:w-[35%] overflow-y-auto pl-10 pr-6 py-6"
                 >
                     <!-- 影片播放器 -->
-                    <div class="video-container w-full max-w-[380px] lg:max-w-[440px] mb-6">
-                        <div class="relative aspect-video rounded-2xl overflow-hidden shadow-2xl shadow-black/50 bg-black">
+                    <div
+                        class="video-container w-full max-w-[380px] lg:max-w-[440px] mb-6"
+                    >
+                        <div
+                            class="relative aspect-video rounded-2xl overflow-hidden shadow-2xl shadow-black/50 bg-black"
+                        >
                             <YTPlayer
                                 v-if="currentVideoId"
                                 :video-id="currentVideoId"
@@ -396,7 +389,9 @@ onUnmounted(() => {
                     </div>
 
                     <!-- 歌曲資訊 -->
-                    <div class="song-info w-full max-w-[380px] lg:max-w-[440px] mb-5">
+                    <div
+                        class="song-info w-full max-w-[380px] lg:max-w-[440px] mb-5"
+                    >
                         <!-- 標題 -->
                         <h1
                             class="text-white text-2xl lg:text-3xl font-bold tracking-tight leading-tight line-clamp-2"
@@ -413,7 +408,10 @@ onUnmounted(() => {
                             >
                                 {{ currentSong.displayArtist || "未知藝人" }}
                             </button>
-                            <span v-else class="text-white/40 text-sm lg:text-base">
+                            <span
+                                v-else
+                                class="text-white/40 text-sm lg:text-base"
+                            >
                                 {{ currentSong.displayArtist || "未知藝人" }}
                             </span>
                         </div>
@@ -457,7 +455,9 @@ onUnmounted(() => {
                     </div>
 
                     <!-- 進度條 -->
-                    <div class="duration-bar-container w-full max-w-[380px] lg:max-w-[440px] mb-3">
+                    <div
+                        class="duration-bar-container w-full max-w-[380px] lg:max-w-[440px] mb-3"
+                    >
                         <div class="relative w-full group cursor-pointer">
                             <div
                                 class="relative w-full h-1 bg-white/10 rounded-full overflow-hidden"
@@ -469,22 +469,30 @@ onUnmounted(() => {
                                 />
                                 <div
                                     class="absolute top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity shadow-lg"
-                                    :style="{ left: `calc(${durationPercent}% - 6px)` }"
+                                    :style="{
+                                        left: `calc(${durationPercent}% - 6px)`,
+                                    }"
                                 />
                             </div>
                         </div>
                         <div class="flex justify-between mt-1.5">
-                            <span class="text-[10px] font-mono text-white/40 tracking-tight">
+                            <span
+                                class="text-[10px] font-mono text-white/40 tracking-tight"
+                            >
                                 {{ formattedCurrentTime }}
                             </span>
-                            <span class="text-[10px] font-mono text-white/40 tracking-tight">
+                            <span
+                                class="text-[10px] font-mono text-white/40 tracking-tight"
+                            >
                                 {{ formattedSongDuration }}
                             </span>
                         </div>
                     </div>
 
                     <!-- 播放控制 -->
-                    <div class="playback-controls w-full max-w-[380px] lg:max-w-[440px] mb-4">
+                    <div
+                        class="playback-controls w-full max-w-[380px] lg:max-w-[440px] mb-4"
+                    >
                         <div class="flex items-center justify-center gap-8">
                             <button
                                 @click="rewind10Sec"
@@ -492,7 +500,9 @@ onUnmounted(() => {
                                 title="倒轉 10 秒"
                                 aria-label="倒轉 10 秒"
                             >
-                                <span class="material-icons text-2xl">replay_10</span>
+                                <span class="material-icons text-2xl"
+                                    >replay_10</span
+                                >
                             </button>
 
                             <button
@@ -512,13 +522,17 @@ onUnmounted(() => {
                                 title="快轉 10 秒"
                                 aria-label="快轉 10 秒"
                             >
-                                <span class="material-icons text-2xl">forward_10</span>
+                                <span class="material-icons text-2xl"
+                                    >forward_10</span
+                                >
                             </button>
                         </div>
                     </div>
 
                     <!-- 音量 + 功能按鈕 -->
-                    <div class="utility-controls w-full max-w-[380px] lg:max-w-[440px] flex items-center justify-between">
+                    <div
+                        class="utility-controls w-full max-w-[380px] lg:max-w-[440px] flex items-center justify-between"
+                    >
                         <div class="flex items-center gap-2">
                             <button
                                 @click="toggleMute"
@@ -527,7 +541,11 @@ onUnmounted(() => {
                                 aria-label="靜音切換"
                             >
                                 <span class="material-icons text-xl">
-                                    {{ volume === 0 || isMuted ? "volume_off" : "volume_up" }}
+                                    {{
+                                        volume === 0 || isMuted
+                                            ? "volume_off"
+                                            : "volume_up"
+                                    }}
                                 </span>
                             </button>
                             <input
@@ -540,7 +558,8 @@ onUnmounted(() => {
                                 @input="
                                     changeVolume(
                                         Number(
-                                            ($event.target as HTMLInputElement).value,
+                                            ($event.target as HTMLInputElement)
+                                                .value,
                                         ),
                                     )
                                 "
@@ -554,7 +573,9 @@ onUnmounted(() => {
                                 title="分享"
                                 aria-label="分享"
                             >
-                                <span class="material-icons text-xl">share</span>
+                                <span class="material-icons text-xl"
+                                    >share</span
+                                >
                             </button>
                             <button
                                 @click="settingModalOpen = true"
@@ -562,7 +583,9 @@ onUnmounted(() => {
                                 title="設定"
                                 aria-label="設定"
                             >
-                                <span class="material-icons text-xl">settings</span>
+                                <span class="material-icons text-xl"
+                                    >settings</span
+                                >
                             </button>
                             <button
                                 @click="aboutModalOpen = true"
@@ -577,7 +600,9 @@ onUnmounted(() => {
                 </div>
 
                 <!-- ── 右側面板：歌詞 ── -->
-                <div class="right-panel flex-1 overflow-hidden relative">
+                <div
+                    class="right-panel flex-1 overflow-hidden relative pr-10 pb-10"
+                >
                     <LyricsContainer
                         :lines="processedLines"
                         :song="currentSong"
@@ -603,7 +628,10 @@ onUnmounted(() => {
                 <!-- 歌詞區域（獨立捲軸） -->
                 <div
                     class="flex-1 overflow-y-auto overflow-x-hidden"
-                    :class="{ 'mb-[140px]': !mobilePanelCollapsed, 'mb-[72px]': mobilePanelCollapsed }"
+                    :class="{
+                        'mb-[140px]': !mobilePanelCollapsed,
+                        'mb-[72px]': mobilePanelCollapsed,
+                    }"
                 >
                     <LyricsContainer
                         :lines="processedLines"
@@ -631,30 +659,50 @@ onUnmounted(() => {
                     >
                         <!-- 可收合區塊：歌曲資訊 -->
                         <div :class="{ hidden: mobilePanelCollapsed }">
-                            <div class="px-5 pt-4 pb-3 flex items-start justify-between">
+                            <div
+                                class="px-5 pt-4 pb-3 flex items-start justify-between"
+                            >
                                 <div class="flex-1 min-w-0 mr-3">
-                                    <h2 class="text-white text-base font-bold truncate tracking-tight">
-                                        {{ currentSong.title || currentSong.folder }}
+                                    <h2
+                                        class="text-white text-base font-bold truncate tracking-tight"
+                                    >
+                                        {{
+                                            currentSong.title ||
+                                            currentSong.folder
+                                        }}
                                     </h2>
-                                    <div class="flex items-center gap-2 mt-0.5 flex-wrap">
+                                    <div
+                                        class="flex items-center gap-2 mt-0.5 flex-wrap"
+                                    >
                                         <button
                                             v-if="currentSong.credits"
                                             @click="creditModalOpen = true"
                                             class="text-white/50 hover:text-white text-xs transition-colors truncate"
                                         >
-                                            {{ currentSong.displayArtist || "未知藝人" }}
+                                            {{
+                                                currentSong.displayArtist ||
+                                                "未知藝人"
+                                            }}
                                         </button>
-                                        <span v-else class="text-white/40 text-xs truncate">
-                                            {{ currentSong.displayArtist || "未知藝人" }}
+                                        <span
+                                            v-else
+                                            class="text-white/40 text-xs truncate"
+                                        >
+                                            {{
+                                                currentSong.displayArtist ||
+                                                "未知藝人"
+                                            }}
                                         </span>
                                         <span
                                             v-if="songVersion !== ORIGINAL"
                                             class="px-1.5 py-0.5 text-[9px] font-bold rounded-md border uppercase tracking-wider"
                                             :class="{
                                                 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30':
-                                                    songVersion === INSTRUMENTAL,
+                                                    songVersion ===
+                                                    INSTRUMENTAL,
                                                 'bg-white/10 text-white border-white/20':
-                                                    songVersion === THE_FIRST_TAKE,
+                                                    songVersion ===
+                                                    THE_FIRST_TAKE,
                                                 'bg-rose-500/20 text-rose-400 border-rose-500/30':
                                                     songVersion === LIVE,
                                             }"
@@ -662,7 +710,8 @@ onUnmounted(() => {
                                             {{
                                                 songVersion === INSTRUMENTAL
                                                     ? "Inst."
-                                                    : songVersion === THE_FIRST_TAKE
+                                                    : songVersion ===
+                                                        THE_FIRST_TAKE
                                                       ? "TFT"
                                                       : songVersion === LIVE
                                                         ? "Live"
@@ -677,32 +726,45 @@ onUnmounted(() => {
                                         class="p-1.5 text-white/50 hover:text-white rounded-full transition-colors"
                                         aria-label="分享"
                                     >
-                                        <span class="material-icons text-lg">share</span>
+                                        <span class="material-icons text-lg"
+                                            >share</span
+                                        >
                                     </button>
                                     <button
                                         @click="settingModalOpen = true"
                                         class="p-1.5 text-white/50 hover:text-white rounded-full transition-colors"
                                         aria-label="設定"
                                     >
-                                        <span class="material-icons text-lg">settings</span>
+                                        <span class="material-icons text-lg"
+                                            >settings</span
+                                        >
                                     </button>
                                 </div>
                             </div>
 
                             <!-- YTPlayer（手機版隱藏，僅供音源） -->
-                            <div class="w-0 h-0 overflow-hidden opacity-0 pointer-events-none">
+                            <div
+                                class="w-0 h-0 overflow-hidden opacity-0 pointer-events-none"
+                            >
                                 <YTPlayer
                                     v-if="currentVideoId"
                                     :video-id="currentVideoId"
                                     @update:current-time="currentTime = $event"
                                     @update:is-paused="isPaused = $event"
-                                    @update:song-duration="songDuration = $event"
+                                    @update:song-duration="
+                                        songDuration = $event
+                                    "
                                 />
                             </div>
                         </div>
 
                         <!-- 永遠顯示：進度條 + 控制按鈕 -->
-                        <div :class="{ 'px-5': true, 'pb-2': mobilePanelCollapsed }">
+                        <div
+                            :class="{
+                                'px-5': true,
+                                'pb-2': mobilePanelCollapsed,
+                            }"
+                        >
                             <!-- 進度條（手機版） -->
                             <div
                                 class="relative w-full h-1 bg-white/10 rounded-full overflow-hidden cursor-pointer mb-3"
@@ -717,10 +779,14 @@ onUnmounted(() => {
 
                             <!-- 時間標籤 -->
                             <div class="flex justify-between -mt-1 mb-2">
-                                <span class="text-[9px] font-mono text-white/35 tracking-tight">
+                                <span
+                                    class="text-[9px] font-mono text-white/35 tracking-tight"
+                                >
                                     {{ formattedCurrentTime }}
                                 </span>
-                                <span class="text-[9px] font-mono text-white/35 tracking-tight">
+                                <span
+                                    class="text-[9px] font-mono text-white/35 tracking-tight"
+                                >
                                     {{ formattedSongDuration }}
                                 </span>
                             </div>
@@ -735,7 +801,11 @@ onUnmounted(() => {
                                         aria-label="靜音切換"
                                     >
                                         <span class="material-icons text-lg">
-                                            {{ volume === 0 || isMuted ? "volume_off" : "volume_up" }}
+                                            {{
+                                                volume === 0 || isMuted
+                                                    ? "volume_off"
+                                                    : "volume_up"
+                                            }}
                                         </span>
                                     </button>
                                     <input
@@ -747,7 +817,9 @@ onUnmounted(() => {
                                         @input="
                                             changeVolume(
                                                 Number(
-                                                    ($event.target as HTMLInputElement).value,
+                                                    (
+                                                        $event.target as HTMLInputElement
+                                                    ).value,
                                                 ),
                                             )
                                         "
@@ -761,16 +833,26 @@ onUnmounted(() => {
                                         class="text-white/50 hover:text-white transition-all active:scale-90"
                                         aria-label="倒轉 10 秒"
                                     >
-                                        <span class="material-icons text-xl">replay_10</span>
+                                        <span class="material-icons text-xl"
+                                            >replay_10</span
+                                        >
                                     </button>
 
                                     <button
-                                        @click="isPaused ? playVideo() : pauseVideo()"
+                                        @click="
+                                            isPaused
+                                                ? playVideo()
+                                                : pauseVideo()
+                                        "
                                         class="w-12 h-12 flex items-center justify-center bg-white text-black rounded-full shadow-[0_0_20px_rgba(255,255,255,0.2)] hover:scale-105 active:scale-95 transition-all"
                                         aria-label="播放 / 暫停"
                                     >
                                         <span class="material-icons text-3xl">
-                                            {{ isPaused ? "play_arrow" : "pause" }}
+                                            {{
+                                                isPaused
+                                                    ? "play_arrow"
+                                                    : "pause"
+                                            }}
                                         </span>
                                     </button>
 
@@ -779,20 +861,28 @@ onUnmounted(() => {
                                         class="text-white/50 hover:text-white transition-all active:scale-90"
                                         aria-label="快轉 10 秒"
                                     >
-                                        <span class="material-icons text-xl">forward_10</span>
+                                        <span class="material-icons text-xl"
+                                            >forward_10</span
+                                        >
                                     </button>
                                 </div>
 
                                 <!-- 收合按鈕 -->
                                 <button
-                                    @click="mobilePanelCollapsed = !mobilePanelCollapsed"
+                                    @click="
+                                        mobilePanelCollapsed =
+                                            !mobilePanelCollapsed
+                                    "
                                     class="text-white/40 hover:text-white/80 transition-colors"
                                     aria-label="展開/收合"
                                 >
                                     <span
                                         class="material-icons transition-transform duration-300"
-                                        :class="{ 'rotate-180': mobilePanelCollapsed }"
-                                    >expand_more</span>
+                                        :class="{
+                                            'rotate-180': mobilePanelCollapsed,
+                                        }"
+                                        >expand_more</span
+                                    >
                                 </button>
                             </div>
                         </div>
@@ -803,8 +893,6 @@ onUnmounted(() => {
             <!-- ── Modals ── -->
             <SettingModal
                 :is-open="settingModalOpen"
-                :bg-color="bgColor"
-                :color-options="colorOptionsList"
                 :enable-lyric-background="enableLyricBackground"
                 :scroll-to-current-line="scrollToCurrentLine"
                 :enable-translation="enableTranslation"
@@ -812,7 +900,6 @@ onUnmounted(() => {
                 :furigana-available="currentSong.furigana == 1"
                 :lyric-font-size="lyricFontSize"
                 @close="settingModalOpen = false"
-                @change-bg-color="bodyBackgroundColor = $event"
                 @update:enableLyricBackground="enableLyricBackground = $event"
                 @update:scrollToCurrentLine="scrollToCurrentLine = $event"
                 @update:enableTranslation="enableTranslation = $event"
@@ -838,9 +925,7 @@ onUnmounted(() => {
                 :is-open="aboutModalOpen"
                 :player-version="PLAYER_VERSION"
                 @close="aboutModalOpen = false"
-                @copy-debug-info="
-                    copyToClipboard(DEBUG_INFO, '偵錯資訊')
-                "
+                @copy-debug-info="copyToClipboard(DEBUG_INFO, '偵錯資訊')"
             />
         </template>
     </div>

--- a/web/components/player/Player.vue
+++ b/web/components/player/Player.vue
@@ -75,6 +75,9 @@ watch(lyricFontSize, (newSize) => {
     localStorage.setItem("lyricFontSize", String(newSize));
 });
 
+// ── 手機版面板收合 ───────────────────────────────────────────────────────
+const mobilePanelCollapsed = ref(false);
+
 // ── Modal 開關 ───────────────────────────────────────────────────────────
 const settingModalOpen = ref(false);
 const creditModalOpen = ref(false);
@@ -113,10 +116,10 @@ const durationPercent = computed(() => {
     return (currentTime.value / songDuration.value) * 100;
 });
 
-const seekTo = (event: Event) => {
-    const target = event.target as HTMLInputElement;
-    const time = (Number(target.value) / 1000) * songDuration.value;
-    window.ytPlayer?.seekTo(time, true);
+const progressBarSeek = (event: MouseEvent) => {
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+    window.ytPlayer?.seekTo(ratio * songDuration.value, true);
 };
 
 // ── 分享連結 ─────────────────────────────────────────────────────────────
@@ -343,7 +346,7 @@ onUnmounted(() => {
 <template>
     <div
         id="body"
-        class="min-h-screen m-0! flex flex-col"
+        class="h-screen m-0! flex flex-col overflow-hidden"
         :style="{ backgroundColor: bodyBackgroundColor }"
     >
         <!-- 載入中 -->
@@ -358,31 +361,42 @@ onUnmounted(() => {
             <!-- 頂部導覽 -->
             <PlayerNav :body-background-color="bodyBackgroundColor" />
 
-            <!-- 主佈局：兩欄式設計 -->
+            <!-- ═══════════════════════════════════════════════════════════ -->
+            <!-- 桌面版：兩欄式佈局                                        -->
+            <!-- ═══════════════════════════════════════════════════════════ -->
             <div
-                class="player-layout flex flex-col md:flex-row flex-1 pt-20 md:pt-24 gap-0"
+                class="hidden md:flex flex-1 overflow-hidden pt-20"
             >
-                <!-- ── 左側面板：歌曲資訊 + 影片 + 控制 ── -->
+                <!-- ── 左側面板：影片 + 歌曲資訊 + 控制 ── -->
                 <div
-                    class="left-panel flex flex-col items-center md:w-[40%] lg:w-[35%] md:fixed md:left-0 md:top-24 md:bottom-0 px-6 py-4 md:overflow-y-auto"
+                    class="left-panel flex flex-col items-center w-[40%] lg:w-[35%] overflow-y-auto px-6 py-6"
                 >
-                    <!-- 專輯封面 -->
-                    <div class="album-art-container w-full max-w-[320px] lg:max-w-[380px] mb-6">
-                        <div class="relative aspect-square rounded-2xl overflow-hidden shadow-2xl shadow-black/40 group">
-                            <img
-                                :src="currentSong.art"
-                                :alt="currentSong.folder"
-                                class="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
+                    <!-- 影片播放器 -->
+                    <div class="video-container w-full max-w-[380px] lg:max-w-[440px] mb-6">
+                        <div class="relative aspect-video rounded-2xl overflow-hidden shadow-2xl shadow-black/50 bg-black">
+                            <YTPlayer
+                                v-if="currentVideoId"
+                                :video-id="currentVideoId"
+                                @update:current-time="currentTime = $event"
+                                @update:is-paused="isPaused = $event"
+                                @update:song-duration="songDuration = $event"
                             />
-                            <!-- 封面光澤疊層 -->
+                            <!-- 無影片時的封面替代 -->
                             <div
-                                class="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent pointer-events-none"
-                            />
+                                v-else
+                                class="w-full h-full flex items-center justify-center"
+                            >
+                                <img
+                                    :src="currentSong.art"
+                                    :alt="currentSong.folder"
+                                    class="w-full h-full object-cover opacity-60"
+                                />
+                            </div>
                         </div>
                     </div>
 
                     <!-- 歌曲資訊 -->
-                    <div class="song-info w-full max-w-[320px] lg:max-w-[380px] mb-5">
+                    <div class="song-info w-full max-w-[380px] lg:max-w-[440px] mb-5">
                         <!-- 標題 -->
                         <h1
                             class="text-white text-2xl lg:text-3xl font-bold tracking-tight leading-tight line-clamp-2"
@@ -390,7 +404,7 @@ onUnmounted(() => {
                             {{ currentSong.title || currentSong.folder }}
                         </h1>
 
-                        <!-- 藝人（可點擊檢視工作人員） -->
+                        <!-- 藝人 -->
                         <div class="flex items-center gap-2 mt-2">
                             <button
                                 v-if="currentSong.credits"
@@ -399,15 +413,12 @@ onUnmounted(() => {
                             >
                                 {{ currentSong.displayArtist || "未知藝人" }}
                             </button>
-                            <span
-                                v-else
-                                class="text-white/40 text-sm lg:text-base"
-                            >
+                            <span v-else class="text-white/40 text-sm lg:text-base">
                                 {{ currentSong.displayArtist || "未知藝人" }}
                             </span>
                         </div>
 
-                        <!-- 專輯名稱 + 版本徽章 -->
+                        <!-- 專輯 + 版本徽章 -->
                         <div class="flex items-center gap-2 mt-2 flex-wrap">
                             <span class="text-white/40 text-xs lg:text-sm">
                                 {{ currentSong.album?.name || "單曲" }}
@@ -446,28 +457,22 @@ onUnmounted(() => {
                     </div>
 
                     <!-- 進度條 -->
-                    <div class="duration-bar-container w-full max-w-[320px] lg:max-w-[380px] mb-3">
-                        <div class="relative w-full group">
-                            <!-- 進度條背景軌道 -->
-                            <div class="relative w-full h-1 bg-white/10 rounded-full overflow-hidden cursor-pointer"
-                                 @click="(e: MouseEvent) => {
-                                     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                                     const ratio = (e.clientX - rect.left) / rect.width;
-                                     window.ytPlayer?.seekTo(ratio * songDuration, true);
-                                 }">
-                                <!-- 已播放進度 -->
+                    <div class="duration-bar-container w-full max-w-[380px] lg:max-w-[440px] mb-3">
+                        <div class="relative w-full group cursor-pointer">
+                            <div
+                                class="relative w-full h-1 bg-white/10 rounded-full overflow-hidden"
+                                @click="progressBarSeek"
+                            >
                                 <div
-                                    class="absolute top-0 left-0 h-full bg-white rounded-full transition-all duration-100 ease-linear group-hover:bg-teal-400"
+                                    class="absolute top-0 left-0 h-full bg-white rounded-full transition-all duration-100 ease-linear group-hover:!bg-teal-400"
                                     :style="{ width: durationPercent + '%' }"
                                 />
-                                <!-- 拖曳圓點 -->
                                 <div
                                     class="absolute top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity shadow-lg"
                                     :style="{ left: `calc(${durationPercent}% - 6px)` }"
                                 />
                             </div>
                         </div>
-                        <!-- 時間標籤 -->
                         <div class="flex justify-between mt-1.5">
                             <span class="text-[10px] font-mono text-white/40 tracking-tight">
                                 {{ formattedCurrentTime }}
@@ -479,9 +484,8 @@ onUnmounted(() => {
                     </div>
 
                     <!-- 播放控制 -->
-                    <div class="playback-controls w-full max-w-[320px] lg:max-w-[380px] mb-4">
+                    <div class="playback-controls w-full max-w-[380px] lg:max-w-[440px] mb-4">
                         <div class="flex items-center justify-center gap-8">
-                            <!-- 倒轉 10 秒 -->
                             <button
                                 @click="rewind10Sec"
                                 class="text-white/50 hover:text-white transition-all transform active:scale-90"
@@ -491,7 +495,6 @@ onUnmounted(() => {
                                 <span class="material-icons text-2xl">replay_10</span>
                             </button>
 
-                            <!-- 播放 / 暫停 -->
                             <button
                                 @click="isPaused ? playVideo() : pauseVideo()"
                                 class="w-16 h-16 flex items-center justify-center bg-white text-black rounded-full shadow-[0_0_30px_rgba(255,255,255,0.25)] hover:scale-105 active:scale-95 transition-all"
@@ -503,7 +506,6 @@ onUnmounted(() => {
                                 </span>
                             </button>
 
-                            <!-- 快轉 10 秒 -->
                             <button
                                 @click="moveForward10Sec"
                                 class="text-white/50 hover:text-white transition-all transform active:scale-90"
@@ -515,9 +517,8 @@ onUnmounted(() => {
                         </div>
                     </div>
 
-                    <!-- 音量控制 + 功能按鈕 -->
-                    <div class="utility-controls w-full max-w-[320px] lg:max-w-[380px] flex items-center justify-between">
-                        <!-- 音量 -->
+                    <!-- 音量 + 功能按鈕 -->
+                    <div class="utility-controls w-full max-w-[380px] lg:max-w-[440px] flex items-center justify-between">
                         <div class="flex items-center gap-2">
                             <button
                                 @click="toggleMute"
@@ -546,7 +547,6 @@ onUnmounted(() => {
                             />
                         </div>
 
-                        <!-- 功能按鈕 -->
                         <div class="flex items-center gap-1">
                             <button
                                 @click="shareModalOpen = true"
@@ -574,22 +574,36 @@ onUnmounted(() => {
                             </button>
                         </div>
                     </div>
-
-                    <!-- YouTube 播放器（隱藏，僅供音源） -->
-                    <div class="w-0 h-0 overflow-hidden opacity-0 pointer-events-none">
-                        <YTPlayer
-                            v-if="currentVideoId"
-                            :video-id="currentVideoId"
-                            @update:current-time="currentTime = $event"
-                            @update:is-paused="isPaused = $event"
-                            @update:song-duration="songDuration = $event"
-                        />
-                    </div>
                 </div>
 
                 <!-- ── 右側面板：歌詞 ── -->
+                <div class="right-panel flex-1 overflow-hidden relative">
+                    <LyricsContainer
+                        :lines="processedLines"
+                        :song="currentSong"
+                        :active-line-indices="activeLineIndices"
+                        :current-time="currentTime"
+                        :enable-lyric-background="enableLyricBackground"
+                        :enable-translation="enableTranslation"
+                        :enable-pronounciation="enablePronounciation"
+                        :lyric-font-size="lyricFontSize"
+                        :is-active-phrase="isActivePhrase"
+                        :is-current-line="isCurrentLine"
+                        :get-phrase-style="getPhraseStyle"
+                        :get-background-phrase-style="getBackgroundPhraseStyle"
+                        @jump="jumpToCurrentLine"
+                    />
+                </div>
+            </div>
+
+            <!-- ═══════════════════════════════════════════════════════════ -->
+            <!-- 手機版：全螢幕歌詞 + 底部固定控制欄                      -->
+            <!-- ═══════════════════════════════════════════════════════════ -->
+            <div class="md:hidden flex-1 flex flex-col overflow-hidden pt-16">
+                <!-- 歌詞區域（獨立捲軸） -->
                 <div
-                    class="right-panel flex-1 md:ml-[40%] lg:ml-[35%] md:min-h-screen"
+                    class="flex-1 overflow-y-auto overflow-x-hidden"
+                    :class="{ 'mb-[140px]': !mobilePanelCollapsed, 'mb-[72px]': mobilePanelCollapsed }"
                 >
                     <LyricsContainer
                         :lines="processedLines"
@@ -607,6 +621,183 @@ onUnmounted(() => {
                         @jump="jumpToCurrentLine"
                     />
                 </div>
+
+                <!-- 手機版底部控制面板 -->
+                <section
+                    class="fixed bottom-0 left-0 right-0 z-50 px-3 pb-3 pt-0 transition-all duration-300"
+                >
+                    <div
+                        class="bg-[#1a1a1a]/90 backdrop-blur-xl rounded-[24px] border border-white/10 shadow-2xl overflow-hidden"
+                    >
+                        <!-- 可收合區塊：歌曲資訊 -->
+                        <div :class="{ hidden: mobilePanelCollapsed }">
+                            <div class="px-5 pt-4 pb-3 flex items-start justify-between">
+                                <div class="flex-1 min-w-0 mr-3">
+                                    <h2 class="text-white text-base font-bold truncate tracking-tight">
+                                        {{ currentSong.title || currentSong.folder }}
+                                    </h2>
+                                    <div class="flex items-center gap-2 mt-0.5 flex-wrap">
+                                        <button
+                                            v-if="currentSong.credits"
+                                            @click="creditModalOpen = true"
+                                            class="text-white/50 hover:text-white text-xs transition-colors truncate"
+                                        >
+                                            {{ currentSong.displayArtist || "未知藝人" }}
+                                        </button>
+                                        <span v-else class="text-white/40 text-xs truncate">
+                                            {{ currentSong.displayArtist || "未知藝人" }}
+                                        </span>
+                                        <span
+                                            v-if="songVersion !== ORIGINAL"
+                                            class="px-1.5 py-0.5 text-[9px] font-bold rounded-md border uppercase tracking-wider"
+                                            :class="{
+                                                'bg-cyan-500/20 text-cyan-400 border-cyan-500/30':
+                                                    songVersion === INSTRUMENTAL,
+                                                'bg-white/10 text-white border-white/20':
+                                                    songVersion === THE_FIRST_TAKE,
+                                                'bg-rose-500/20 text-rose-400 border-rose-500/30':
+                                                    songVersion === LIVE,
+                                            }"
+                                        >
+                                            {{
+                                                songVersion === INSTRUMENTAL
+                                                    ? "Inst."
+                                                    : songVersion === THE_FIRST_TAKE
+                                                      ? "TFT"
+                                                      : songVersion === LIVE
+                                                        ? "Live"
+                                                        : songVersion
+                                            }}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="flex gap-1 shrink-0">
+                                    <button
+                                        @click="shareModalOpen = true"
+                                        class="p-1.5 text-white/50 hover:text-white rounded-full transition-colors"
+                                        aria-label="分享"
+                                    >
+                                        <span class="material-icons text-lg">share</span>
+                                    </button>
+                                    <button
+                                        @click="settingModalOpen = true"
+                                        class="p-1.5 text-white/50 hover:text-white rounded-full transition-colors"
+                                        aria-label="設定"
+                                    >
+                                        <span class="material-icons text-lg">settings</span>
+                                    </button>
+                                </div>
+                            </div>
+
+                            <!-- YTPlayer（手機版隱藏，僅供音源） -->
+                            <div class="w-0 h-0 overflow-hidden opacity-0 pointer-events-none">
+                                <YTPlayer
+                                    v-if="currentVideoId"
+                                    :video-id="currentVideoId"
+                                    @update:current-time="currentTime = $event"
+                                    @update:is-paused="isPaused = $event"
+                                    @update:song-duration="songDuration = $event"
+                                />
+                            </div>
+                        </div>
+
+                        <!-- 永遠顯示：進度條 + 控制按鈕 -->
+                        <div :class="{ 'px-5': true, 'pb-2': mobilePanelCollapsed }">
+                            <!-- 進度條（手機版） -->
+                            <div
+                                class="relative w-full h-1 bg-white/10 rounded-full overflow-hidden cursor-pointer mb-3"
+                                :class="{ 'mt-3': mobilePanelCollapsed }"
+                                @click="progressBarSeek"
+                            >
+                                <div
+                                    class="absolute top-0 left-0 h-full bg-white rounded-full"
+                                    :style="{ width: durationPercent + '%' }"
+                                />
+                            </div>
+
+                            <!-- 時間標籤 -->
+                            <div class="flex justify-between -mt-1 mb-2">
+                                <span class="text-[9px] font-mono text-white/35 tracking-tight">
+                                    {{ formattedCurrentTime }}
+                                </span>
+                                <span class="text-[9px] font-mono text-white/35 tracking-tight">
+                                    {{ formattedSongDuration }}
+                                </span>
+                            </div>
+
+                            <!-- 控制按鈕 -->
+                            <div class="flex items-center justify-between pb-3">
+                                <!-- 音量 -->
+                                <div class="flex items-center gap-1.5">
+                                    <button
+                                        @click="toggleMute"
+                                        class="text-white/50 hover:text-white transition-colors"
+                                        aria-label="靜音切換"
+                                    >
+                                        <span class="material-icons text-lg">
+                                            {{ volume === 0 || isMuted ? "volume_off" : "volume_up" }}
+                                        </span>
+                                    </button>
+                                    <input
+                                        type="range"
+                                        min="0"
+                                        max="100"
+                                        :value="volume"
+                                        class="w-16 h-1 bg-white/20 rounded-full appearance-none accent-white cursor-pointer"
+                                        @input="
+                                            changeVolume(
+                                                Number(
+                                                    ($event.target as HTMLInputElement).value,
+                                                ),
+                                            )
+                                        "
+                                    />
+                                </div>
+
+                                <!-- 核心播放按鈕 -->
+                                <div class="flex items-center gap-8">
+                                    <button
+                                        @click="rewind10Sec"
+                                        class="text-white/50 hover:text-white transition-all active:scale-90"
+                                        aria-label="倒轉 10 秒"
+                                    >
+                                        <span class="material-icons text-xl">replay_10</span>
+                                    </button>
+
+                                    <button
+                                        @click="isPaused ? playVideo() : pauseVideo()"
+                                        class="w-12 h-12 flex items-center justify-center bg-white text-black rounded-full shadow-[0_0_20px_rgba(255,255,255,0.2)] hover:scale-105 active:scale-95 transition-all"
+                                        aria-label="播放 / 暫停"
+                                    >
+                                        <span class="material-icons text-3xl">
+                                            {{ isPaused ? "play_arrow" : "pause" }}
+                                        </span>
+                                    </button>
+
+                                    <button
+                                        @click="moveForward10Sec"
+                                        class="text-white/50 hover:text-white transition-all active:scale-90"
+                                        aria-label="快轉 10 秒"
+                                    >
+                                        <span class="material-icons text-xl">forward_10</span>
+                                    </button>
+                                </div>
+
+                                <!-- 收合按鈕 -->
+                                <button
+                                    @click="mobilePanelCollapsed = !mobilePanelCollapsed"
+                                    class="text-white/40 hover:text-white/80 transition-colors"
+                                    aria-label="展開/收合"
+                                >
+                                    <span
+                                        class="material-icons transition-transform duration-300"
+                                        :class="{ 'rotate-180': mobilePanelCollapsed }"
+                                    >expand_more</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </section>
             </div>
 
             <!-- ── Modals ── -->
@@ -707,12 +898,5 @@ input[type="range"]:hover::-moz-range-thumb {
 }
 .left-panel::-webkit-scrollbar-track {
     background: transparent;
-}
-
-/* ── 專輯封面發光效果 ── */
-.album-art-container .shadow-2xl {
-    box-shadow:
-        0 25px 50px -12px rgba(0, 0, 0, 0.5),
-        0 0 40px -10px v-bind("bodyBackgroundColor + '66'");
 }
 </style>

--- a/web/components/player/Player.vue
+++ b/web/components/player/Player.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 // ── Types ────────────────────────────────────────────────────────────────
 import type {
     LyricData,
@@ -19,21 +19,27 @@ import {
     parseLyrics,
 } from "@/composables/hooks/useSongs";
 import {
+    ALBUM_GOOGLE_LINK_BASE,
     DEBUG_INFO,
     INSTRUMENTAL,
     LIVE,
     ORIGINAL,
+    PLAYER_VERSION,
     THE_FIRST_TAKE,
     TSL_PLAYER_LINK_BASE,
     TSL_SUFFIX,
 } from "@/composables/utils/config";
-import { formatTime, scrollToLineIndex } from "@/composables/utils/global";
+import { copyToClipboard, formatTime, scrollToLineIndex } from "@/composables/utils/global";
 import type { Color } from "@/types/song_select";
-import ControllerPanel from "@components/player/ControllerPanel.vue";
+import AboutModal from "@components/player/AboutModal.vue";
+import CreditModal from "@components/player/CreditModal.vue";
 import ErrorDisplay from "@components/player/ErrorDisplay.vue";
 import LoadingOverlay from "@components/player/LoadingOverlay.vue";
 import LyricsContainer from "@components/player/LyricsContainer.vue";
 import PlayerNav from "@components/player/PlayerNav.vue";
+import SettingModal from "@components/player/SettingModal.vue";
+import ShareModal from "@components/player/ShareModal.vue";
+import YTPlayer from "@components/player/YTPlayer.vue";
 import colorOptions from "@composables/colorOptions.json";
 
 // ── URL 參數 ─────────────────────────────────────────────────────────────
@@ -61,6 +67,20 @@ const errorMessage = ref("");
 
 const currentSong = ref<SongWithDisplay | null>(null);
 
+// ── 字型大小設定 ─────────────────────────────────────────────────────────
+const lyricFontSize = ref<number>(
+    Number(localStorage.getItem("lyricFontSize")) || 24,
+);
+watch(lyricFontSize, (newSize) => {
+    localStorage.setItem("lyricFontSize", String(newSize));
+});
+
+// ── Modal 開關 ───────────────────────────────────────────────────────────
+const settingModalOpen = ref(false);
+const creditModalOpen = ref(false);
+const shareModalOpen = ref(false);
+const aboutModalOpen = ref(false);
+
 // ── 顏色 ─────────────────────────────────────────────────────────────────
 const colorOptionsList = ref<Color[]>(
     colorOptions || [{ color: "#365456", name: "預設 II：礦石靛" }],
@@ -87,12 +107,31 @@ const bgColor = computed(
 const formattedCurrentTime = computed(() => formatTime(currentTime.value));
 const formattedSongDuration = computed(() => formatTime(songDuration.value));
 
+// ── 進度條 ───────────────────────────────────────────────────────────────
+const durationPercent = computed(() => {
+    if (songDuration.value === 0) return 0;
+    return (currentTime.value / songDuration.value) * 100;
+});
+
+const seekTo = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    const time = (Number(target.value) / 1000) * songDuration.value;
+    window.ytPlayer?.seekTo(time, true);
+};
+
 // ── 分享連結 ─────────────────────────────────────────────────────────────
 const currentSongURI = computed(() => {
     if (!currentSong.value) return "";
     if (songVersion.value === ORIGINAL)
         return `${TSL_PLAYER_LINK_BASE}?song=${currentSong.value.song_id}`;
     return `${TSL_PLAYER_LINK_BASE}?song=${currentSong.value.song_id}&version=${songVersion.value}`;
+});
+
+// ── 當前影片 ID ──────────────────────────────────────────────────────────
+const currentVideoId = computed(() => {
+    return currentSong.value?.versions.find(
+        (v: Version) => v.version === songVersion.value,
+    )?.id ?? null;
 });
 
 // ── processedLines：計算每行結束時間 ─────────────────────────────────────
@@ -233,8 +272,6 @@ async function loadSongLyric() {
     );
 }
 
-// ── 翻譯 ─────────────────────────────────────────────────────────────────
-
 // ── 初始化 ───────────────────────────────────────────────────────────────
 async function setup() {
     try {
@@ -269,6 +306,16 @@ async function setup() {
     }
 }
 
+// ── Keyboard handler ─────────────────────────────────────────────────────
+function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+        settingModalOpen.value = false;
+        creditModalOpen.value = false;
+        shareModalOpen.value = false;
+        aboutModalOpen.value = false;
+    }
+}
+
 // ── Watchers ──────────────────────────────────────────────────────────────
 watch(currentLineIndex, (newVal) => {
     if (newVal === -1 || typeof newVal === "undefined") return;
@@ -283,13 +330,20 @@ watch(volume, (newVal) => {
 });
 
 // ── 啟動 ─────────────────────────────────────────────────────────────────
-onMounted(setup);
+onMounted(() => {
+    window.addEventListener("keydown", onKeydown);
+    setup();
+});
+
+onUnmounted(() => {
+    window.removeEventListener("keydown", onKeydown);
+});
 </script>
 
 <template>
     <div
         id="body"
-        class="min-h-screen m-0!"
+        class="min-h-screen m-0! flex flex-col"
         :style="{ backgroundColor: bodyBackgroundColor }"
     >
         <!-- 載入中 -->
@@ -304,69 +358,361 @@ onMounted(setup);
             <!-- 頂部導覽 -->
             <PlayerNav :body-background-color="bodyBackgroundColor" />
 
-            <!-- 左側：歌詞 -->
+            <!-- 主佈局：兩欄式設計 -->
             <div
-                id="main-display-section"
-                class="md:flex flex-col items-center md:w-5/6 md:mx-8 px-10 pt-20"
+                class="player-layout flex flex-col md:flex-row flex-1 pt-20 md:pt-24 gap-0"
             >
-                <LyricsContainer
-                    :lines="processedLines"
-                    :song="currentSong"
-                    :active-line-indices="activeLineIndices"
-                    :current-time="currentTime"
-                    :enable-lyric-background="enableLyricBackground"
-                    :enable-translation="enableTranslation"
-                    :enable-pronounciation="enablePronounciation"
-                    :is-active-phrase="isActivePhrase"
-                    :is-current-line="isCurrentLine"
-                    :get-phrase-style="getPhraseStyle"
-                    :get-background-phrase-style="getBackgroundPhraseStyle"
-                    @jump="jumpToCurrentLine"
-                />
+                <!-- ── 左側面板：歌曲資訊 + 影片 + 控制 ── -->
+                <div
+                    class="left-panel flex flex-col items-center md:w-[40%] lg:w-[35%] md:fixed md:left-0 md:top-24 md:bottom-0 px-6 py-4 md:overflow-y-auto"
+                >
+                    <!-- 專輯封面 -->
+                    <div class="album-art-container w-full max-w-[320px] lg:max-w-[380px] mb-6">
+                        <div class="relative aspect-square rounded-2xl overflow-hidden shadow-2xl shadow-black/40 group">
+                            <img
+                                :src="currentSong.art"
+                                :alt="currentSong.folder"
+                                class="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
+                            />
+                            <!-- 封面光澤疊層 -->
+                            <div
+                                class="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent pointer-events-none"
+                            />
+                        </div>
+                    </div>
+
+                    <!-- 歌曲資訊 -->
+                    <div class="song-info w-full max-w-[320px] lg:max-w-[380px] mb-5">
+                        <!-- 標題 -->
+                        <h1
+                            class="text-white text-2xl lg:text-3xl font-bold tracking-tight leading-tight line-clamp-2"
+                        >
+                            {{ currentSong.title || currentSong.folder }}
+                        </h1>
+
+                        <!-- 藝人（可點擊檢視工作人員） -->
+                        <div class="flex items-center gap-2 mt-2">
+                            <button
+                                v-if="currentSong.credits"
+                                @click="creditModalOpen = true"
+                                class="text-white/60 hover:text-white text-sm lg:text-base transition-colors underline underline-offset-4 md:no-underline md:hover:underline"
+                            >
+                                {{ currentSong.displayArtist || "未知藝人" }}
+                            </button>
+                            <span
+                                v-else
+                                class="text-white/40 text-sm lg:text-base"
+                            >
+                                {{ currentSong.displayArtist || "未知藝人" }}
+                            </span>
+                        </div>
+
+                        <!-- 專輯名稱 + 版本徽章 -->
+                        <div class="flex items-center gap-2 mt-2 flex-wrap">
+                            <span class="text-white/40 text-xs lg:text-sm">
+                                {{ currentSong.album?.name || "單曲" }}
+                            </span>
+                            <span
+                                v-if="songVersion !== ORIGINAL"
+                                class="px-2 py-0.5 text-[10px] font-bold rounded-md border uppercase tracking-wider"
+                                :class="{
+                                    'bg-cyan-500/20 text-cyan-400 border-cyan-500/30':
+                                        songVersion === INSTRUMENTAL,
+                                    'bg-white/10 text-white border-white/20':
+                                        songVersion === THE_FIRST_TAKE,
+                                    'bg-rose-500/20 text-rose-400 border-rose-500/30':
+                                        songVersion === LIVE,
+                                }"
+                            >
+                                {{
+                                    songVersion === INSTRUMENTAL
+                                        ? "Instrumental"
+                                        : songVersion === THE_FIRST_TAKE
+                                          ? "The First Take"
+                                          : songVersion === LIVE
+                                            ? "Live"
+                                            : songVersion
+                                }}
+                            </span>
+                        </div>
+
+                        <!-- 副標題 -->
+                        <p
+                            v-if="currentSong.subtitle"
+                            class="text-white/30 text-xs mt-2 line-clamp-2 italic"
+                        >
+                            {{ parseSubtitle(currentSong.subtitle) }}
+                        </p>
+                    </div>
+
+                    <!-- 進度條 -->
+                    <div class="duration-bar-container w-full max-w-[320px] lg:max-w-[380px] mb-3">
+                        <div class="relative w-full group">
+                            <!-- 進度條背景軌道 -->
+                            <div class="relative w-full h-1 bg-white/10 rounded-full overflow-hidden cursor-pointer"
+                                 @click="(e: MouseEvent) => {
+                                     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                                     const ratio = (e.clientX - rect.left) / rect.width;
+                                     window.ytPlayer?.seekTo(ratio * songDuration, true);
+                                 }">
+                                <!-- 已播放進度 -->
+                                <div
+                                    class="absolute top-0 left-0 h-full bg-white rounded-full transition-all duration-100 ease-linear group-hover:bg-teal-400"
+                                    :style="{ width: durationPercent + '%' }"
+                                />
+                                <!-- 拖曳圓點 -->
+                                <div
+                                    class="absolute top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity shadow-lg"
+                                    :style="{ left: `calc(${durationPercent}% - 6px)` }"
+                                />
+                            </div>
+                        </div>
+                        <!-- 時間標籤 -->
+                        <div class="flex justify-between mt-1.5">
+                            <span class="text-[10px] font-mono text-white/40 tracking-tight">
+                                {{ formattedCurrentTime }}
+                            </span>
+                            <span class="text-[10px] font-mono text-white/40 tracking-tight">
+                                {{ formattedSongDuration }}
+                            </span>
+                        </div>
+                    </div>
+
+                    <!-- 播放控制 -->
+                    <div class="playback-controls w-full max-w-[320px] lg:max-w-[380px] mb-4">
+                        <div class="flex items-center justify-center gap-8">
+                            <!-- 倒轉 10 秒 -->
+                            <button
+                                @click="rewind10Sec"
+                                class="text-white/50 hover:text-white transition-all transform active:scale-90"
+                                title="倒轉 10 秒"
+                                aria-label="倒轉 10 秒"
+                            >
+                                <span class="material-icons text-2xl">replay_10</span>
+                            </button>
+
+                            <!-- 播放 / 暫停 -->
+                            <button
+                                @click="isPaused ? playVideo() : pauseVideo()"
+                                class="w-16 h-16 flex items-center justify-center bg-white text-black rounded-full shadow-[0_0_30px_rgba(255,255,255,0.25)] hover:scale-105 active:scale-95 transition-all"
+                                title="播放 / 暫停"
+                                aria-label="播放 / 暫停"
+                            >
+                                <span class="material-icons text-4xl">
+                                    {{ isPaused ? "play_arrow" : "pause" }}
+                                </span>
+                            </button>
+
+                            <!-- 快轉 10 秒 -->
+                            <button
+                                @click="moveForward10Sec"
+                                class="text-white/50 hover:text-white transition-all transform active:scale-90"
+                                title="快轉 10 秒"
+                                aria-label="快轉 10 秒"
+                            >
+                                <span class="material-icons text-2xl">forward_10</span>
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- 音量控制 + 功能按鈕 -->
+                    <div class="utility-controls w-full max-w-[320px] lg:max-w-[380px] flex items-center justify-between">
+                        <!-- 音量 -->
+                        <div class="flex items-center gap-2">
+                            <button
+                                @click="toggleMute"
+                                class="text-white/50 hover:text-white transition-colors"
+                                title="靜音"
+                                aria-label="靜音切換"
+                            >
+                                <span class="material-icons text-xl">
+                                    {{ volume === 0 || isMuted ? "volume_off" : "volume_up" }}
+                                </span>
+                            </button>
+                            <input
+                                id="player-volume-slider"
+                                type="range"
+                                min="0"
+                                max="100"
+                                :value="volume"
+                                class="w-24 h-1 bg-white/20 rounded-full appearance-none accent-white cursor-pointer"
+                                @input="
+                                    changeVolume(
+                                        Number(
+                                            ($event.target as HTMLInputElement).value,
+                                        ),
+                                    )
+                                "
+                            />
+                        </div>
+
+                        <!-- 功能按鈕 -->
+                        <div class="flex items-center gap-1">
+                            <button
+                                @click="shareModalOpen = true"
+                                class="p-2 text-white/50 hover:text-white hover:bg-white/10 rounded-full transition-all"
+                                title="分享"
+                                aria-label="分享"
+                            >
+                                <span class="material-icons text-xl">share</span>
+                            </button>
+                            <button
+                                @click="settingModalOpen = true"
+                                class="p-2 text-white/50 hover:text-white hover:bg-white/10 rounded-full transition-all"
+                                title="設定"
+                                aria-label="設定"
+                            >
+                                <span class="material-icons text-xl">settings</span>
+                            </button>
+                            <button
+                                @click="aboutModalOpen = true"
+                                class="p-2 text-white/30 hover:text-white/70 transition-colors"
+                                title="關於"
+                                aria-label="關於"
+                            >
+                                <span class="material-icons text-lg">info</span>
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- YouTube 播放器（隱藏，僅供音源） -->
+                    <div class="w-0 h-0 overflow-hidden opacity-0 pointer-events-none">
+                        <YTPlayer
+                            v-if="currentVideoId"
+                            :video-id="currentVideoId"
+                            @update:current-time="currentTime = $event"
+                            @update:is-paused="isPaused = $event"
+                            @update:song-duration="songDuration = $event"
+                        />
+                    </div>
+                </div>
+
+                <!-- ── 右側面板：歌詞 ── -->
+                <div
+                    class="right-panel flex-1 md:ml-[40%] lg:ml-[35%] md:min-h-screen"
+                >
+                    <LyricsContainer
+                        :lines="processedLines"
+                        :song="currentSong"
+                        :active-line-indices="activeLineIndices"
+                        :current-time="currentTime"
+                        :enable-lyric-background="enableLyricBackground"
+                        :enable-translation="enableTranslation"
+                        :enable-pronounciation="enablePronounciation"
+                        :lyric-font-size="lyricFontSize"
+                        :is-active-phrase="isActivePhrase"
+                        :is-current-line="isCurrentLine"
+                        :get-phrase-style="getPhraseStyle"
+                        :get-background-phrase-style="getBackgroundPhraseStyle"
+                        @jump="jumpToCurrentLine"
+                    />
+                </div>
             </div>
 
-            <!-- 右側：播放控制面板（含 Modals） -->
-            <ControllerPanel
-                :current-song="currentSong"
-                :song-version="songVersion"
-                :is-paused="isPaused"
-                :is-muted="isMuted"
-                :volume="volume"
-                :formatted-current-time="formattedCurrentTime"
-                :formatted-song-duration="formattedSongDuration"
-                :ORIGINAL="ORIGINAL"
-                :INSTRUMENTAL="INSTRUMENTAL"
-                :THE_FIRST_TAKE="THE_FIRST_TAKE"
-                :LIVE="LIVE"
-                :parse-subtitle="parseSubtitle"
-                :video-id="
-                    currentSong.versions.find(
-                        (v: Version) => v.version === songVersion,
-                    )?.id ?? null
-                "
+            <!-- ── Modals ── -->
+            <SettingModal
+                :is-open="settingModalOpen"
                 :bg-color="bgColor"
                 :color-options="colorOptionsList"
                 :enable-lyric-background="enableLyricBackground"
                 :scroll-to-current-line="scrollToCurrentLine"
                 :enable-translation="enableTranslation"
                 :enable-pronounciation="enablePronounciation"
-                :current-song-u-r-i="currentSongURI"
-                :debug-info="DEBUG_INFO"
-                @update:current-time="currentTime = $event"
-                @update:is-paused="isPaused = $event"
-                @update:song-duration="songDuration = $event"
-                @play="playVideo"
-                @pause="pauseVideo"
-                @rewind="rewind10Sec"
-                @forward="moveForward10Sec"
-                @toggle-mute="toggleMute"
-                @change-volume="changeVolume"
+                :furigana-available="currentSong.furigana == 1"
+                :lyric-font-size="lyricFontSize"
+                @close="settingModalOpen = false"
                 @change-bg-color="bodyBackgroundColor = $event"
                 @update:enableLyricBackground="enableLyricBackground = $event"
                 @update:scrollToCurrentLine="scrollToCurrentLine = $event"
                 @update:enableTranslation="enableTranslation = $event"
                 @update:enablePronounciation="enablePronounciation = $event"
+                @update:lyricFontSize="lyricFontSize = $event"
+            />
+
+            <CreditModal
+                :is-open="creditModalOpen"
+                :current-song="currentSong"
+                :ALBUM_GOOGLE_LINK_BASE="ALBUM_GOOGLE_LINK_BASE"
+                @close="creditModalOpen = false"
+            />
+
+            <ShareModal
+                :is-open="shareModalOpen"
+                :current-song-u-r-i="currentSongURI"
+                @close="shareModalOpen = false"
+                @copy-link="copyToClipboard($event, '歌曲連結')"
+            />
+
+            <AboutModal
+                :is-open="aboutModalOpen"
+                :player-version="PLAYER_VERSION"
+                @close="aboutModalOpen = false"
+                @copy-debug-info="
+                    copyToClipboard(DEBUG_INFO, '偵錯資訊')
+                "
             />
         </template>
     </div>
 </template>
+
+<style scoped>
+/* ── 進度條樣式 ── */
+input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
+    height: 4px;
+    border-radius: 2px;
+    outline: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #fff;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+input[type="range"]:hover::-webkit-slider-thumb {
+    opacity: 1;
+}
+
+input[type="range"]::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #fff;
+    cursor: pointer;
+    border: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+input[type="range"]:hover::-moz-range-thumb {
+    opacity: 1;
+}
+
+/* ── 左側面板捲軸 ── */
+.left-panel::-webkit-scrollbar {
+    width: 3px;
+}
+.left-panel::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+}
+.left-panel::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+/* ── 專輯封面發光效果 ── */
+.album-art-container .shadow-2xl {
+    box-shadow:
+        0 25px 50px -12px rgba(0, 0, 0, 0.5),
+        0 0 40px -10px v-bind("bodyBackgroundColor + '66'");
+}
+</style>

--- a/web/components/player/PlayerNav.vue
+++ b/web/components/player/PlayerNav.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 defineProps<{
-    bodyBackgroundColor: string;
+    dominantColor: string;
 }>();
 </script>
 
 <template>
     <nav>
         <div
-            class="top-0 fixed w-full py-4 z-50 backdrop-blur-md transition-all duration-300"
-            :style="{ backgroundColor: `${bodyBackgroundColor}cc` }"
+            class="top-0 fixed w-full py-4 z-50 backdrop-blur-xl transition-all duration-1000"
+            :style="{
+                background: `linear-gradient(to bottom, ${dominantColor}40 0%, ${dominantColor}10 100%)`,
+            }"
         >
             <div
                 class="flex flex-row justify-between items-center w-full px-4 md:px-8"
@@ -42,12 +44,7 @@ defineProps<{
                         />
                         <a href="/" class="hover:opacity-80 transition-opacity">
                             <h1
-                                class="text-xl md:text-2xl font-bold tracking-tight font-playfair"
-                                :class="
-                                    bodyBackgroundColor === '#101010'
-                                        ? 'text-rose-500'
-                                        : 'text-white/90'
-                                "
+                                class="text-xl md:text-2xl font-bold tracking-tight font-playfair text-white/90"
                             >
                                 同步開唱
                             </h1>

--- a/web/components/player/SettingModal.vue
+++ b/web/components/player/SettingModal.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
-import type { Color } from "@/types/song_select";
-
 const props = defineProps<{
     isOpen: boolean;
-    bgColor: Color;
-    colorOptions: Color[];
     enableLyricBackground: boolean;
     scrollToCurrentLine: boolean;
     enableTranslation: boolean;
@@ -15,7 +11,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{
     (e: "close"): void;
-    (e: "change-bg-color", color: string): void;
     (e: "update:enableLyricBackground", val: boolean): void;
     (e: "update:scrollToCurrentLine", val: boolean): void;
     (e: "update:enableTranslation", val: boolean): void;
@@ -32,7 +27,7 @@ const emit = defineEmits<{
 
             <!-- 內容 -->
             <div
-                class="modal-mutual bg-[#455a47] top-2/5 left-[10%] w-4/5 md:left-[30%] md:top-[30%] md:w-2/5"
+                class="modal-mutual top-2/5 left-[10%] w-4/5 md:left-[30%] md:top-[30%] md:w-2/5"
             >
                 <!-- 標題列 -->
                 <div class="flex flex-row items-center">
@@ -53,9 +48,9 @@ const emit = defineEmits<{
                     <div class="settings-entry flex-col">
                         <div class="flex items-center justify-between w-full">
                             <label class="text-base">歌詞字型大小</label>
-                            <span class="text-sm font-mono text-white/60">{{
-                                lyricFontSize
-                            }}px</span>
+                            <span class="text-sm font-mono text-white/60">
+                                {{ lyricFontSize }}px
+                            </span>
                         </div>
                         <div class="flex items-center gap-3 w-full mt-2">
                             <span class="text-xs text-white/40">16px</span>
@@ -87,51 +82,6 @@ const emit = defineEmits<{
                             >
                                 歌詞預覽 Aa
                             </span>
-                        </div>
-                    </div>
-
-                    <!-- 背景顏色 -->
-                    <div class="settings-entry">
-                        <label>背景顏色：</label>
-                        <div class="flex flex-row gap-2 items-center mt-1">
-                            <span class="flex gap-2 text-sm text-white/70">
-                                <span
-                                    class="color-preview w-5 h-5 border border-gray-200 rounded-sm"
-                                    :style="{
-                                        backgroundColor: bgColor.color,
-                                    }"
-                                ></span>
-                                <span class="text-sm font-mono">{{
-                                    bgColor.name
-                                }}</span>
-                            </span>
-                            <details class="relative">
-                                <summary
-                                    class="cursor-pointer text-sm text-teal-300 underline list-none"
-                                >
-                                    選擇顏色
-                                </summary>
-                                <div
-                                    class="mt-2 p-3 bg-gray-800 rounded-xl border border-white/20 flex flex-wrap gap-2 w-52 shadow-2xl"
-                                >
-                                    <button
-                                        v-for="colorObj in colorOptions"
-                                        :key="colorObj.color"
-                                        class="w-7 h-7 rounded-full border-2 border-white/20 hover:scale-125 transition-transform"
-                                        :style="{
-                                            backgroundColor: colorObj.color,
-                                        }"
-                                        :title="colorObj.name"
-                                        :aria-label="colorObj.name"
-                                        @click="
-                                            emit(
-                                                'change-bg-color',
-                                                colorObj.color,
-                                            )
-                                        "
-                                    />
-                                </div>
-                            </details>
                         </div>
                     </div>
 

--- a/web/components/player/SettingModal.vue
+++ b/web/components/player/SettingModal.vue
@@ -10,6 +10,7 @@ const props = defineProps<{
     enableTranslation: boolean;
     enablePronounciation: boolean;
     furiganaAvailable: boolean | null;
+    lyricFontSize: number;
 }>();
 
 const emit = defineEmits<{
@@ -19,6 +20,7 @@ const emit = defineEmits<{
     (e: "update:scrollToCurrentLine", val: boolean): void;
     (e: "update:enableTranslation", val: boolean): void;
     (e: "update:enablePronounciation", val: boolean): void;
+    (e: "update:lyricFontSize", val: number): void;
 }>();
 </script>
 
@@ -47,6 +49,47 @@ const emit = defineEmits<{
                 </div>
 
                 <div class="modal-view-area custom-scrollbar">
+                    <!-- 歌詞字型大小 -->
+                    <div class="settings-entry flex-col">
+                        <div class="flex items-center justify-between w-full">
+                            <label class="text-base">歌詞字型大小</label>
+                            <span class="text-sm font-mono text-white/60">{{
+                                lyricFontSize
+                            }}px</span>
+                        </div>
+                        <div class="flex items-center gap-3 w-full mt-2">
+                            <span class="text-xs text-white/40">16px</span>
+                            <input
+                                type="range"
+                                min="16"
+                                max="40"
+                                :value="lyricFontSize"
+                                class="w-full h-1.5 bg-white/20 rounded-full appearance-none accent-teal-400 cursor-pointer"
+                                @input="
+                                    emit(
+                                        'update:lyricFontSize',
+                                        Number(
+                                            ($event.target as HTMLInputElement)
+                                                .value,
+                                        ),
+                                    )
+                                "
+                            />
+                            <span class="text-xs text-white/40">40px</span>
+                        </div>
+                        <!-- 預覽 -->
+                        <div
+                            class="mt-2 py-2 px-4 bg-black/20 rounded-lg w-full text-center"
+                        >
+                            <span
+                                class="text-white/80 transition-all duration-150"
+                                :style="{ fontSize: lyricFontSize + 'px' }"
+                            >
+                                歌詞預覽 Aa
+                            </span>
+                        </div>
+                    </div>
+
                     <!-- 背景顏色 -->
                     <div class="settings-entry">
                         <label>背景顏色：</label>

--- a/web/components/player/TranslationBar.vue
+++ b/web/components/player/TranslationBar.vue
@@ -14,19 +14,19 @@ defineEmits<{ (e: "disableTranslation"): void }>();
 <template>
     <div
         id="translation-container"
-        class="z-2 hidden md:block absolute bottom-6 left-4"
+        class="z-2 hidden md:block absolute bottom-6 left-4 max-w-md"
     >
         <template v-if="song.translation?.available">
             <div
-                class="p-4 flex flex-col items-start gap-2 bg-[#231f1f]/90 backdrop-blur-md rounded-xl shadow-lg border border-white/5"
+                class="p-5 flex flex-col items-start gap-2 bg-white/[0.04] backdrop-blur-xl rounded-2xl border border-white/[0.06]"
             >
-                <div class="text-2xl font-bold text-teal-300 p-2">
+                <div class="text-2xl font-bold text-white/90 leading-snug">
                     {{ translationText }}
-                    <div class="mt-1 text-base text-teal-500">
+                    <div class="mt-1 text-base font-normal text-white/50">
                         {{ backgroundTranslationText }}
                     </div>
                 </div>
-                <div class="mt-2">
+                <div class="mt-1">
                     <a
                         v-if="song.translation?.cite"
                         :href="song.translation?.cite"
@@ -34,11 +34,11 @@ defineEmits<{ (e: "disableTranslation"): void }>();
                         aria-label="翻譯作者姓名"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-xs font-bold text-green-400 underline md:no-underline md:hover:underline"
+                        class="text-xs font-medium text-white/35 hover:text-white/70 underline decoration-white/20 hover:decoration-white/50 underline-offset-2 transition-colors"
                     >
                         翻譯作者：{{ translationAuthor }}
                     </a>
-                    <div v-else class="text-xs text-white/60">
+                    <div v-else class="text-xs text-white/25">
                         翻譯作者：{{ translationAuthor }}
                     </div>
                 </div>
@@ -46,9 +46,9 @@ defineEmits<{ (e: "disableTranslation"): void }>();
         </template>
         <template v-else>
             <div
-                class="p-4 flex flex-col items-start gap-2 bg-[#231f1f]/80 backdrop-blur-md rounded-xl shadow-lg border border-white/5"
+                class="p-4 flex flex-col items-start gap-2 bg-white/[0.03] backdrop-blur-xl rounded-2xl border border-white/[0.04]"
             >
-                <span class="text-white/60">本歌曲尚未提供翻譯</span>
+                <span class="text-white/25 text-sm">本歌曲尚未提供翻譯</span>
             </div>
         </template>
     </div>

--- a/web/components/player/TranslationBar.vue
+++ b/web/components/player/TranslationBar.vue
@@ -12,14 +12,17 @@ defineEmits<{ (e: "disableTranslation"): void }>();
 </script>
 
 <template>
-    <div id="translation-container" class="z-2 hidden md:block absolute bottom-6 left-1/2 -translate-x-1/2">
+    <div
+        id="translation-container"
+        class="z-2 hidden md:block absolute bottom-6 left-4"
+    >
         <template v-if="song.translation?.available">
             <div
-                class="p-4 flex flex-col items-center gap-2 bg-[#231f1f]/90 backdrop-blur-md rounded-xl shadow-lg border border-white/5"
+                class="p-4 flex flex-col items-start gap-2 bg-[#231f1f]/90 backdrop-blur-md rounded-xl shadow-lg border border-white/5"
             >
-                <div class="text-2xl font-bold text-center text-teal-300 p-2">
+                <div class="text-2xl font-bold text-teal-300 p-2">
                     {{ translationText }}
-                    <div class="mt-1 text-base text-center text-teal-500">
+                    <div class="mt-1 text-base text-teal-500">
                         {{ backgroundTranslationText }}
                     </div>
                 </div>
@@ -31,11 +34,11 @@ defineEmits<{ (e: "disableTranslation"): void }>();
                         aria-label="翻譯作者姓名"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-xs font-bold text-center text-green-400 underline md:no-underline md:hover:underline"
+                        class="text-xs font-bold text-green-400 underline md:no-underline md:hover:underline"
                     >
                         翻譯作者：{{ translationAuthor }}
                     </a>
-                    <div v-else class="text-xs text-center text-white/60">
+                    <div v-else class="text-xs text-white/60">
                         翻譯作者：{{ translationAuthor }}
                     </div>
                 </div>
@@ -43,7 +46,7 @@ defineEmits<{ (e: "disableTranslation"): void }>();
         </template>
         <template v-else>
             <div
-                class="p-4 flex flex-col items-center gap-2 bg-[#231f1f]/80 backdrop-blur-md rounded-xl shadow-lg border border-white/5"
+                class="p-4 flex flex-col items-start gap-2 bg-[#231f1f]/80 backdrop-blur-md rounded-xl shadow-lg border border-white/5"
             >
                 <span class="text-white/60">本歌曲尚未提供翻譯</span>
             </div>

--- a/web/components/player/TranslationBar.vue
+++ b/web/components/player/TranslationBar.vue
@@ -12,10 +12,10 @@ defineEmits<{ (e: "disableTranslation"): void }>();
 </script>
 
 <template>
-    <div id="translation-container" class="z-2 hidden md:block fixed bottom-10">
+    <div id="translation-container" class="z-2 hidden md:block absolute bottom-6 left-1/2 -translate-x-1/2">
         <template v-if="song.translation?.available">
             <div
-                class="p-4 flex flex-col items-center gap-2 bg-[#231f1f] opacity-90 rounded-xl w-max"
+                class="p-4 flex flex-col items-center gap-2 bg-[#231f1f]/90 backdrop-blur-md rounded-xl shadow-lg border border-white/5"
             >
                 <div class="text-2xl font-bold text-center text-teal-300 p-2">
                     {{ translationText }}
@@ -43,7 +43,7 @@ defineEmits<{ (e: "disableTranslation"): void }>();
         </template>
         <template v-else>
             <div
-                class="p-4 flex flex-col items-center gap-2 bg-[#231f1f] opacity-80 rounded-xl w-fit"
+                class="p-4 flex flex-col items-center gap-2 bg-[#231f1f]/80 backdrop-blur-md rounded-xl shadow-lg border border-white/5"
             >
                 <span class="text-white/60">本歌曲尚未提供翻譯</span>
             </div>

--- a/web/components/player/YTPlayer.vue
+++ b/web/components/player/YTPlayer.vue
@@ -23,7 +23,7 @@ let rafId: number | null = null;
 // ── Helpers ────────────────────────────────────────────────────────────────
 const calcSize = () => {
     if (window.screen.width >= 960 && window.screen.height >= 768) {
-        return { width: "300", height: "200" };
+        return { width: "100%", height: "100%" };
     }
     return { width: "0", height: "0" };
 };
@@ -137,10 +137,10 @@ defineExpose({
 </script>
 
 <template>
-    <div ref="playerContainer">
+    <div ref="playerContainer" class="w-full h-full">
         <div
             id="player"
-            class="w-0 h-0 md:w-full md:h-full bg-white/10 rounded-2xl relative group cursor-pointer"
+            class="w-full h-full bg-black rounded-2xl relative"
         />
     </div>
 </template>

--- a/web/composables/hooks/useAlbumColors.ts
+++ b/web/composables/hooks/useAlbumColors.ts
@@ -1,0 +1,146 @@
+import { ref, watch } from "vue";
+
+export interface AlbumGradient {
+    gradient: string;
+    dominant: string;
+    palette: string[];
+}
+
+/**
+ * 從專輯封面提取主色並生成深色漸層背景
+ * Extract dominant colors from album art and generate a dark gradient
+ */
+export function useAlbumColors(imageUrl: () => string | undefined) {
+    const colors = ref<AlbumGradient>({
+        gradient:
+            "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
+        dominant: "#1a1a2e",
+        palette: ["#1a1a2e", "#16213e", "#0f3460"],
+    });
+
+    async function extractColors(url: string): Promise<AlbumGradient> {
+        return new Promise((resolve) => {
+            const img = new Image();
+            img.crossOrigin = "anonymous";
+
+            img.onload = () => {
+                try {
+                    const canvas = document.createElement("canvas");
+                    const sampleSize = 50;
+                    canvas.width = sampleSize;
+                    canvas.height = sampleSize;
+                    const ctx = canvas.getContext("2d");
+                    if (!ctx) throw new Error("No canvas context");
+
+                    ctx.drawImage(img, 0, 0, sampleSize, sampleSize);
+                    const imageData = ctx.getImageData(
+                        0,
+                        0,
+                        sampleSize,
+                        sampleSize,
+                    );
+                    const pixels = imageData.data;
+
+                    // 收集量化後的顏色並計數
+                    const colorCounts = new Map<string, number>();
+                    for (let i = 0; i < pixels.length; i += 4) {
+                        const r = pixels[i];
+                        const g = pixels[i + 1];
+                        const b = pixels[i + 2];
+                        const a = pixels[i + 3];
+                        if (a < 128) continue; // 跳過透明像素
+
+                        // 量化至 32 級以減少顏色數量
+                        const qr = Math.round(r / 32) * 32;
+                        const qg = Math.round(g / 32) * 32;
+                        const qb = Math.round(b / 32) * 32;
+                        const key = `${qr},${qg},${qb}`;
+                        colorCounts.set(
+                            key,
+                            (colorCounts.get(key) || 0) + 1,
+                        );
+                    }
+
+                    // 按出現次數排序，取前 5 個主色
+                    const sorted = [...colorCounts.entries()]
+                        .sort((a, b) => b[1] - a[1])
+                        .slice(0, 5);
+
+                    const palette = sorted.map(([key]) => {
+                        const [r, g, b] = key.split(",").map(Number);
+                        return `rgb(${r},${g},${b})`;
+                    });
+
+                    if (palette.length === 0) {
+                        // 無有效像素時回退
+                        resolve({
+                            gradient:
+                                "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
+                            dominant: "#1a1a2e",
+                            palette: ["#1a1a2e", "#16213e", "#0f3460"],
+                        });
+                        return;
+                    }
+
+                    // 根據主色計算深色版本用於背景漸層
+                    const dark1 = darkenHex(palette[0], 0.25);
+                    const dark2 = darkenHex(
+                        palette[1] || palette[0],
+                        0.2,
+                    );
+                    const dark3 = darkenHex(
+                        palette[2] || palette[0],
+                        0.3,
+                    );
+
+                    const gradient = `linear-gradient(135deg, ${dark1} 0%, ${dark2} 50%, ${dark3} 100%)`;
+                    const dominant = dark1;
+
+                    resolve({ gradient, dominant, palette });
+                } catch {
+                    // Canvas 操作失敗時回退
+                    resolve({
+                        gradient:
+                            "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
+                        dominant: "#1a1a2e",
+                        palette: ["#1a1a2e", "#16213e", "#0f3460"],
+                    });
+                }
+            };
+
+            img.onerror = () => {
+                resolve({
+                    gradient:
+                        "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
+                    dominant: "#1a1a2e",
+                    palette: ["#1a1a2e", "#16213e", "#0f3460"],
+                });
+            };
+
+            img.src = url;
+        });
+    }
+
+    /** 將 rgb(r,g,b) 轉換為 hex 並調暗 */
+    function darkenHex(rgb: string, factor: number): string {
+        const match = rgb.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+        if (!match) return rgb;
+        const r = Math.round(Number(match[1]) * factor);
+        const g = Math.round(Number(match[2]) * factor);
+        const b = Math.round(Number(match[3]) * factor);
+        return `rgb(${r},${g},${b})`;
+    }
+
+    // 監聽圖片 URL 變更，自動提取顏色
+    watch(
+        imageUrl,
+        async (url) => {
+            if (url) {
+                colors.value = await extractColors(url);
+            }
+        },
+        { immediate: true },
+    );
+
+    return { colors };
+}


### PR DESCRIPTION
@
## Summary

A comprehensive redesign of the player page with a modern two-panel streaming layout and several visual refinements.

## Changes

- **Two-panel desktop layout**: Left panel (40%) for video, song info, and controls; right panel (60%) for lyrics — giving each its own scrollable space
- **Album art gradient extraction**: Background dynamically pulls colors from the album art instead of a manual color picker
- **Glass-morphism translation bar**: Replaced solid dark container and hardcoded teal/green accents with a frosted-glass panel using white opacity — blends into the album-art-driven background
- **Mobile bottom bar**: Collapsible control panel fixed at the bottom with song info, progress bar, and playback controls
- **Scroll fixes**: Proper right margin (`mr-4 md:mr-12`) on lyrics for breathing room
- **Video replaces static album art**: Embedded YouTube player in the left panel

## Screenshots

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@