### PR TITLE
fix(player): constrain translation bar to lyric container bottom on d…

### DIFF
--- a/web/components/player/Player.vue
+++ b/web/components/player/Player.vue
@@ -803,7 +803,7 @@ onUnmounted(() => {
                         :background-translation-text="backgroundTranslationText"
                         :translation-author="translationAuthor"
                         :translation-modified="translationModified"
-                        class="z-2 absolute bottom-6 left-4 right-auto max-w-md"
+                        class="z-2 absolute bottom-6 md:bottom-10 left-4 right-auto max-w-md md:max-w-none md:w-1/2"
                     />
                 </div>
             </div>

--- a/web/components/player/TranslationBar.vue
+++ b/web/components/player/TranslationBar.vue
@@ -18,9 +18,13 @@ defineEmits<{ (e: "disableTranslation"): void }>();
             <div
                 class="p-3 md:p-5 flex flex-col items-start gap-1.5 md:gap-2 bg-white/4 backdrop-blur-xl rounded-2xl border border-white/6"
             >
-                <div class="text-lg md:text-2xl font-bold text-white/90 leading-snug">
+                <div
+                    class="text-lg md:text-2xl font-bold text-white/90 leading-snug"
+                >
                     {{ translationText }}
-                    <div class="mt-1 text-sm md:text-base font-normal text-white/50">
+                    <div
+                        class="mt-1 text-sm md:text-base font-normal text-white/50"
+                    >
                         {{ backgroundTranslationText }}
                     </div>
                 </div>
@@ -38,14 +42,16 @@ defineEmits<{ (e: "disableTranslation"): void }>();
                         }}<span
                             v-if="translationModified"
                             class="ml-1.5 px-1.5 py-0.5 rounded-md bg-zinc-300/20 text-[10px] text-zinc-300 font-normal no-underline"
-                        >有更動</span>
+                            >有更動</span
+                        >
                     </a>
                     <div v-else class="text-[10px] md:text-xs text-zinc-300/60">
                         翻譯作者：{{ translationAuthor
                         }}<span
                             v-if="translationModified"
                             class="ml-1.5 px-1.5 py-0.5 rounded-md bg-zinc-300/15 text-[10px] text-zinc-300/90 font-normal"
-                        >有更動</span>
+                            >有更動</span
+                        >
                     </div>
                 </div>
             </div>
@@ -54,7 +60,9 @@ defineEmits<{ (e: "disableTranslation"): void }>();
             <div
                 class="p-3 md:p-4 flex flex-col items-start gap-2 bg-white/3 backdrop-blur-xl rounded-2xl border border-white/4"
             >
-                <span class="text-white/25 text-xs md:text-sm">本歌曲尚未提供翻譯</span>
+                <span class="text-white/25 text-xs md:text-sm"
+                    >本歌曲尚未提供翻譯</span
+                >
             </div>
         </template>
     </div>

--- a/web/components/song_select/SongDetailModal.vue
+++ b/web/components/song_select/SongDetailModal.vue
@@ -159,11 +159,16 @@ function parseSubtitle(subtitle: string | null | undefined): string {
                                     >
                                     <span class="text-zinc-300/60"
                                         >譯者：{{
-                                            song.translation?.author ?? "未提供"
+                                            song.translation?.author ??
+                                            "未提供"
                                         }}<span
-                                            v-if="song.translation?.modified === true"
+                                            v-if="
+                                                song.translation?.modified ===
+                                                true
+                                            "
                                             class="ml-1.5 px-1.5 py-0.5 rounded-md bg-zinc-300/15 text-[10px] text-zinc-300 font-normal"
-                                        >有更動</span></span
+                                            >有更動</span
+                                        ></span
                                     >
                                 </div>
                                 <div class="flex items-center gap-2">

--- a/web/composables/hooks/useSongs.ts
+++ b/web/composables/hooks/useSongs.ts
@@ -97,7 +97,10 @@ export const parseLyrics = async (
             if (line.type === "interlude" || line.type === "prelude") {
                 lineText = [{ phrase: "● ● ●", duration: 0 }];
             } else if (line.type === "end") {
-                const creatorName = currentSong.displayLyricist || currentSong.displayArtist || "未知的創作者";
+                const creatorName =
+                    currentSong.displayLyricist ||
+                    currentSong.displayArtist ||
+                    "未知的創作者";
                 const totalDuration = (songDuration - startTime) * 100; // 厘秒
                 lineText = [
                     {

--- a/web/composables/hooks/useTranslation.ts
+++ b/web/composables/hooks/useTranslation.ts
@@ -47,5 +47,10 @@ export function useTranslation(
         return song?.translation?.modified === true;
     });
 
-    return { translationAuthor, translationModified, translationText, backgroundTranslationText };
+    return {
+        translationAuthor,
+        translationModified,
+        translationText,
+        backgroundTranslationText,
+    };
 }

--- a/web/types/player.d.ts
+++ b/web/types/player.d.ts
@@ -42,7 +42,7 @@ export interface Translation {
     available: number | false;
     author: string | "";
     cite?: string;
-    modified?: number | false;
+    modified?: boolean | false;
 }
 
 //  工作人員名單

--- a/web/types/song_select.d.ts
+++ b/web/types/song_select.d.ts
@@ -26,7 +26,7 @@ export interface SongListItem {
     // ensureSongData 後才有的完整欄位
     versions?: SongVersion[];
     subtitle?: string;
-    translation?: { author?: string; available?: boolean };
+    translation?: { author?: string; available?: boolean; modified?: boolean };
     folder?: string;
     furigana?: boolean;
 }


### PR DESCRIPTION
…esktop

Align the translation bar with the lyric container's bottom border using md:bottom-10 to match the right panel's pb-10 padding. Constrain its width to 50% of the lyric container via md:w-1/2 md:max-w-none. Only affects md: breakpoint - mobile layout is unchanged.