### PR TITLE
fix(player): keep last line (lyricist credit) highlighted until song end

### DIFF
--- a/web/components/player/Player.vue
+++ b/web/components/player/Player.vue
@@ -36,15 +36,15 @@ import {
     formatTime,
     scrollToLineIndex,
 } from "@/composables/utils/global";
-import AboutModal from "@components/player/modals/AboutModal.vue";
-import CreditModal from "@components/player/modals/CreditModal.vue";
 import ErrorDisplay from "@components/player/ErrorDisplay.vue";
 import LoadingOverlay from "@components/player/LoadingOverlay.vue";
 import LyricsContainer from "@components/player/lyrics/LyricsContainer.vue";
-import PlayerNav from "@components/player/PlayerNav.vue";
+import TranslationBar from "@components/player/lyrics/TranslationBar.vue";
+import AboutModal from "@components/player/modals/AboutModal.vue";
+import CreditModal from "@components/player/modals/CreditModal.vue";
 import SettingModal from "@components/player/modals/SettingModal.vue";
 import ShareModal from "@components/player/modals/ShareModal.vue";
-import TranslationBar from "@components/player/lyrics/TranslationBar.vue";
+import PlayerNav from "@components/player/PlayerNav.vue";
 import YTPlayer from "@components/player/YTPlayer.vue";
 
 // ── URL 參數 ─────────────────────────────────────────────────────────────
@@ -563,15 +563,15 @@ onUnmounted(() => {
                             </button>
                             <span
                                 v-else
-                                class="text-white/40 text-sm lg:text-base"
+                                class="text-white/50 text-sm lg:text-base"
                             >
                                 {{ currentSong.displayArtist || "未知藝人" }}
                             </span>
                         </div>
 
                         <!-- 專輯 + 版本徽章 -->
-                        <div class="flex items-center gap-2 mt-2 flex-wrap">
-                            <span class="text-white/40 text-xs lg:text-sm">
+                        <div class="flex items-center gap-4 mt-2 flex-wrap">
+                            <span class="text-white/50 text-xs lg:text-sm">
                                 {{ currentSong.album?.name || "單曲" }}
                             </span>
                             <span
@@ -601,7 +601,7 @@ onUnmounted(() => {
                         <!-- 副標題 -->
                         <p
                             v-if="currentSong.subtitle"
-                            class="text-white/30 text-xs mt-2 line-clamp-2 italic"
+                            class="text-white/50 text-xs mt-2 line-clamp-2 italic"
                         >
                             {{ parseSubtitle(currentSong.subtitle) }}
                         </p>

--- a/web/components/player/Player.vue
+++ b/web/components/player/Player.vue
@@ -302,7 +302,7 @@ const activeLineIndices = computed(() => {
                     ? line.computedEndTime
                     : nextLine.time - 0.3;
         } else {
-            endTime = line.computedEndTime + 0.5;
+            endTime = Math.max(line.computedEndTime, songDuration.value) + 0.5;
         }
 
         if (now >= startTime && now < endTime) result.push(index);

--- a/web/components/player/lyrics/LyricPhrase.vue
+++ b/web/components/player/lyrics/LyricPhrase.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { LyricPhrase } from "@/types/player";
 import type { CSSProperties } from "vue";
+import { computed } from "vue";
 
-defineProps<{
+const props = defineProps<{
     phrase: LyricPhrase;
     duration: number;
     delay: number;
@@ -11,6 +12,13 @@ defineProps<{
     isBackground?: boolean;
     enablePronounciation: boolean;
 }>();
+
+const computedStyle = computed<CSSProperties>(() => ({
+    ...props.phraseStyle,
+    fontSize: props.isBackground
+        ? "calc(var(--lyric-font-size) - 10px)"
+        : "var(--lyric-font-size)",
+}));
 </script>
 
 <template>
@@ -19,11 +27,10 @@ defineProps<{
         :class="{
             active: isActive,
             kiai: phrase.kiai,
-            'text-base': isBackground,
         }"
         :duration="duration * 100"
         :delay="delay * 100"
-        :style="phraseStyle"
+        :style="computedStyle"
     >
         <!-- 有注音且強制顯示 -->
         <template v-if="phrase.pronounciation && phrase.pncat_forced">

--- a/web/components/player/lyrics/LyricPhrase.vue
+++ b/web/components/player/lyrics/LyricPhrase.vue
@@ -13,12 +13,20 @@ const props = defineProps<{
     enablePronounciation: boolean;
 }>();
 
-const computedStyle = computed<CSSProperties>(() => ({
-    ...props.phraseStyle,
-    fontSize: props.isBackground
-        ? "calc(var(--lyric-font-size) - 10px)"
-        : "var(--lyric-font-size)",
-}));
+const computedStyle = computed<CSSProperties>(() => {
+    const style = { ...props.phraseStyle };
+    // Only apply default font size when the parent (generatePhraseStyle)
+    // didn't provide one — preserves per-line overrides like the
+    // 20px credit line
+    const hasCustomFontSize =
+        style.fontSize || (style as Record<string, unknown>)["font-size"];
+    if (!hasCustomFontSize) {
+        style.fontSize = props.isBackground
+            ? "calc(var(--lyric-font-size) - 10px)"
+            : "var(--lyric-font-size)";
+    }
+    return style;
+});
 </script>
 
 <template>

--- a/web/composables/hooks/useAlbumColors.ts
+++ b/web/composables/hooks/useAlbumColors.ts
@@ -113,13 +113,21 @@ export function useAlbumColors(imageUrl: () => string | undefined) {
         });
     }
 
-    /** 將 rgb(r,g,b) 轉換為 hex 並調暗 */
+    /**
+     * Darken an rgb(r,g,b) color by the given factor.
+     * The factor controls how dark: 0 = full black, 1 = unchanged.
+     * The output is 50% less dark than a pure multiplicative darken —
+     * it interpolates halfway between the darkened color and the original.
+     */
     function darkenHex(rgb: string, factor: number): string {
         const match = rgb.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
         if (!match) return rgb;
-        const r = Math.round(Number(match[1]) * factor);
-        const g = Math.round(Number(match[2]) * factor);
-        const b = Math.round(Number(match[3]) * factor);
+        // 50% less dark: interpolate halfway back toward the original color
+        // multiplier = factor + (1 - factor) × 0.5 = (1 + factor) / 2
+        const multiplier = (1 + factor) / 2;
+        const r = Math.round(Number(match[1]) * multiplier);
+        const g = Math.round(Number(match[2]) * multiplier);
+        const b = Math.round(Number(match[3]) * multiplier);
         return `rgb(${r},${g},${b})`;
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where the lyricist credit line (the last line of type `end`) only stayed highlighted for ~3 seconds instead of remaining highlighted until the song actually ended.

## Root Cause

In `parseLyrics`, the `end` type line uses `songDuration` to calculate how long the creator name should be visible. However, `songDuration` is `0` during initial setup because the YTPlayer hasn't emitted the actual duration yet. This cascaded through `processedLines` to a `validDuration` fallback of 3.0 seconds.

## Fix

In `activeLineIndices`, the last line's `endTime` now uses `Math.max(line.computedEndTime, songDuration.value)`. Since `songDuration` is a reactive ref updated by YTPlayer, the computed property re-evaluates when the real duration arrives, keeping the last line highlighted until the song actually ends.

## Additional Changes in This PR

- fix(player): don't overwrite custom font-size from `generatePhraseStyle` in LyricPhrase
- fix(player): make album background 50% less dark and brighten text overlays
- feat(player): use `--lyric-font-size` CSS variable for lyric phrase font sizing

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)